### PR TITLE
update to mac installation webpage content

### DIFF
--- a/Mac Installation.html
+++ b/Mac Installation.html
@@ -191,7 +191,7 @@
 </div>
 <blockquote>
   <div>
-    <p>If you get an error relating to unidentified developer software, run the following commands in the Terminal (may require elevated permissions). You may also need to check System Preferences, Security and Privacy as shown <a class="reference external" href="https://tst.usgs.gov/macos/install-unidentified-developer-software/">here</a>.</p>
+    <p>If you get an error relating to unidentified developer software, run the following commands in the Terminal (may require elevated permissions). You may also need to check System Preferences, Security and Privacy as shown <a class="reference external" href="https://support.apple.com/en-us/HT202491">here</a>.</p>
     <p><strong>Open terminal and run:</strong></p>
     <ul>
       <li>sudo spctl --master-disable</li>

--- a/Mac Installation.html
+++ b/Mac Installation.html
@@ -191,6 +191,7 @@
 </div>
 <blockquote>
   <div>
+    <p>If you get an error relating to unidentified developer software, run the following commands in the Terminal (may require elevated permissions). You may also need to check System Preferences, Security and Privacy as shown <a class="reference external" href="https://tst.usgs.gov/macos/install-unidentified-developer-software/">here</a>.</p>
     <p><strong>Open terminal and run:</strong></p>
     <ul>
       <li>sudo spctl --master-disable</li>
@@ -201,7 +202,7 @@
   </div>
 </blockquote>
 <blockquote>
-<div><p><strong>Installation does require elevated (administrative) privileges.</strong> After installation the MetadataWizard can be launched from the duck icon (<a class="reference internal" href="_images/duck.png"><img alt="duck" src="_images/duck.png" style="width: 18pt;" /></a>) in the user’s applications.</p>
+<div><p><strong>Installation may require elevated (administrative) privileges.</strong> After installation the MetadataWizard can be launched from the duck icon (<a class="reference internal" href="_images/duck.png"><img alt="duck" src="_images/duck.png" style="width: 18pt;" /></a>) in the user’s applications.</p>
 </div></blockquote>
 </div>
 


### PR DESCRIPTION
testing whether the new DOI-USGS repo can update the documentation website
2 minor changes to update the content of the mac installation instructions page